### PR TITLE
ENH: add logging proprety machine

### DIFF
--- a/super_state_machine/extras.py
+++ b/super_state_machine/extras.py
@@ -51,3 +51,17 @@ class PropertyMachine(object):
             actual_state = ''
 
         return ProxyString(actual_state, machine)
+
+
+class LoggingPropertyMachine(PropertyMachine):
+    def __init__(self, machine_type, *, logger=None):
+        super(LoggingPropertyMachine, self).__init__(self, machine_type)
+        self._logger = logger
+
+    def __set__(self, obj, value):
+        old_value = self.__get__(obj)
+        super(LoggingPropertyMachine, self).__set__(self, obj, value)
+        value = self.__get__(obj)
+        if self._logger is not None:
+            self._logger.info("Change state on %r from %r -> %r",
+                              obj, old_value, value)


### PR DESCRIPTION
Add a sub-class of PropertyMachine which takes an optional logging in `__init__` which is used to log all state changes at the INFO level.

If this of interest to you to include in main line I will add tests + docs + make level configurable.